### PR TITLE
docs(changelog): missing required params return 400 not 500 (#1245)

### DIFF
--- a/src/content/docs/changelog/index.mdx
+++ b/src/content/docs/changelog/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-lastUpdated: 2026-05-24
+lastUpdated: 2026-05-27
 description: Release notes and version history for fullstackhero.
 sidebar:
   order: 1
@@ -10,6 +10,10 @@ seo:
 ---
 
 Notable changes to the kit, newest first.
+
+## 2026-05-27
+
+- **Missing required request parameters now return `400`, not `500`** — calling a tenant-scoped endpoint without the `tenant` header (and any other endpoint missing a required header/route/query parameter, or sent with an unreadable/oversized body) raised an ASP.NET `BadHttpRequestException` that the global exception handler rendered as a generic `500 Internal Server Error`. The handler now honours the framework's own status code, so these surface as a proper `400 Bad Request` (or `413`, etc.) with a `ProblemDetails` body. Fixes [#1245](https://github.com/fullstackhero/dotnet-starter-kit/issues/1245).
 
 ## 2026-05-24
 


### PR DESCRIPTION
## Summary

Changelog entry for the `BadHttpRequestException` -> 400 fix in the starter kit.

A missing required `tenant` header (and other malformed-request cases — missing required header/route/query params, unreadable/oversized bodies) previously rendered as a generic **500**. The starter kit's `GlobalExceptionHandler` now honours the framework's own status code, so these surface as a proper **400 Bad Request** (or 413, etc.).

Pairs with: fullstackhero/dotnet-starter-kit#1247
Issue: fullstackhero/dotnet-starter-kit#1245

🤖 Generated with [Claude Code](https://claude.com/claude-code)
