### PR TITLE
docs: drop --db from fsh new examples

### DIFF
--- a/src/content/docs/getting-started/install.mdx
+++ b/src/content/docs/getting-started/install.mdx
@@ -48,13 +48,13 @@ dotnet run --project src/Host/MyApp.AppHost
 <Screenshot
   src="/screenshots/install/fsh-new-wizard.png"
   alt="fsh new interactive scaffolding wizard"
-  caption="The fsh new wizard prompts for the project name, database provider, and Aspire AppHost."
+  caption="The fsh new wizard prompts for the project name and what to include (Aspire AppHost, React apps)."
 />
 
 Non-interactive (handy for scripts):
 
 ```bash
-fsh new MyApp --db postgres --no-git
+fsh new MyApp --no-git
 ```
 
 See the [CLI reference](/docs/cli/) for every command (`fsh new`, `doctor`, `info`, `update`) and flag.

--- a/src/content/docs/getting-started/quick-start.mdx
+++ b/src/content/docs/getting-started/quick-start.mdx
@@ -26,12 +26,12 @@ fsh new MyApp
 cd MyApp
 ```
 
-The interactive wizard asks for your database provider and whether to include the Aspire AppHost. Run `fsh doctor` first if you'd like to verify your environment (SDK, Docker, Aspire workload, free ports).
+The interactive wizard asks whether to include the Aspire AppHost and the React client apps. Run `fsh doctor` first if you'd like to verify your environment (SDK, Docker, Aspire workload, free ports).
 
 Want it non-interactive?
 
 ```bash
-fsh new MyApp --db postgres --no-git
+fsh new MyApp --no-git
 ```
 
 ## 3. Run


### PR DESCRIPTION
Follow-up to dotnet-starter-kit#1265, which removes the no-op `--db` option from the CLI/template.

- `getting-started/install.mdx` + `quick-start.mdx`: the non-interactive examples used `fsh new MyApp --db postgres --no-git` (doubly wrong — `--db` is gone, and `postgres` was never a valid value). Now `fsh new MyApp --no-git`.
- Updated the wizard-prompt prose that said it asks for a "database provider" (it no longer does).

Left unchanged: docs describing the backend's SQL Server *provider capability* (`persistence.mdx`, `introduction.mdx` stack table, `StackAtAGlance`) — that abstraction still exists; only the scaffold-time option was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
