### PR TITLE
docs: pre-release hardening (Tickets close/update/delete, Webhooks secrets+permissions)

### DIFF
--- a/src/content/docs/changelog/index.mdx
+++ b/src/content/docs/changelog/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-lastUpdated: 2026-05-28
+lastUpdated: 2026-06-01
 description: Release notes and version history for fullstackhero.
 sidebar:
   order: 1
@@ -10,6 +10,16 @@ seo:
 ---
 
 Notable changes to the kit, newest first.
+
+## 2026-06-01
+
+Post-10.0.0 pre-release hardening from a module-by-module audit (correctness, security, completeness, test coverage) across the backend. Every finding was adversarially verified before fixing; the suite stays green (warnings-as-errors, Testcontainers integration tests).
+
+- **Chat: restoring an archived channel no longer loses its members (fix).** Archiving a channel called `db.Remove(channel)`, which cascaded the delete onto the `ChannelMember` rows; because the soft-delete interceptor only rescues *owned* references, the members were hard-deleted and a later **restore brought back an empty channel** — the creator then got `404` trying to post. Archiving is now an explicit domain state change that flips the soft-delete flag and leaves membership intact, so a restore is lossless.
+- **Tickets: the lifecycle and permission set are now complete.** The `Closed` state was unreachable (no way to get there) and the `Tickets.Update` / `Tickets.Delete` permissions were registered with **no endpoints behind them** — so an admin could grant rights that did nothing, and the existing trash/restore had no way to actually trash a ticket. This adds first-class **Close** (`POST /api/v1/tickets/{id}/close`, Resolved → Closed), **Update** (`PUT /api/v1/tickets/{id}` — edit title/description/priority; frozen once Closed), and **Delete** (`DELETE /api/v1/tickets/{id}` — soft-delete; comments survive and return on restore), each with a validator, a permission gate, and a new `Tickets.Close` permission. `GET /api/v1/tickets/{id}/comments` now returns `404` for a non-existent ticket instead of a misleading empty list. See [Tickets](/docs/modules/tickets/).
+- **Webhooks: signing secrets are encrypted at rest, and the endpoints are permission-gated (security fixes).** The HMAC signing secret was stored as plaintext in a field named `SecretHash` — a database breach would have exposed every tenant's secret. The secret is the HMAC key (it must stay recoverable, so hashing isn't an option), so it is now **encrypted with ASP.NET Data Protection** on create and decrypted only at sign time. Separately, the endpoints were authentication-only — any signed-in user could manage every webhook in their tenant; they now require the new `Webhooks.View` / `Create` / `Delete` / `Test` permissions. **After upgrading, grant these to the roles that manage webhooks or those users will get `403`.** See [Webhooks](/docs/modules/webhooks/).
+- **Multitenancy & correctness.** The `GET tenant provisioning status` and `retry provisioning` endpoints now accept and forward a `CancellationToken` (graceful shutdown); the Notifications mention handler fails loud on a tenant-context mismatch rather than risking a cross-tenant write; webhook list endpoints validate pagination (a `pageSize=0` previously surfaced as a `500`, now a clean `400`); and the Billing monthly-invoice job takes its clock from `TimeProvider` for deterministic tests.
+- **Known follow-up.** Billing publishes its `InvoiceIssued` event directly on the in-memory bus rather than through the transactional outbox (Files does the same, with no consumer yet). Closing this needs a small `Eventing` building-block change to support more than one outbox-backed module; tracked for a follow-up release. The in-memory path is correct today.
 
 ## 10.0.0 — 2026-05-28
 

--- a/src/content/docs/modules/tickets.mdx
+++ b/src/content/docs/modules/tickets.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tickets module
-lastUpdated: 2026-05-19
-description: A complete support-ticket workflow — auto-numbered tickets, status state machine (Open → InProgress → Resolved → Closed), comments, assignment, priority, and soft delete.
+lastUpdated: 2026-06-01
+description: A complete support-ticket workflow — auto-numbered tickets, status state machine (Open → InProgress → Resolved → Closed), comments, assignment, priority, edit, and soft delete.
 sidebar:
   label: Tickets
   order: 10
@@ -21,13 +21,14 @@ If you're adding a domain with strict status transitions (orders, applications, 
 ## What ships in v10
 
 - **Tickets** with auto-generated `Number`, title, optional description, status, priority (Low / Medium / High / Critical), reporter user, and optional assignee.
-- **Four-state status machine**: Open → InProgress → Resolved → Closed, with reopen-from-Resolved-or-Closed support. Every transition raises a `TicketStatusChangedDomainEvent`.
+- **Four-state status machine**: Open → InProgress → Resolved → Closed, with reopen-from-Resolved-or-Closed support. `Close` finalizes a resolved ticket (only `Resolved` → `Closed`; any other source state is rejected with 409). Every transition raises a `TicketStatusChangedDomainEvent`.
 - **Assignment workflow** — assigning when Open moves to InProgress; unassigning from InProgress moves back to Open; assigning Closed is rejected with 409.
+- **Edit** — `Update` revises a ticket's title, description, and priority; a Closed ticket is frozen and must be reopened first (409).
 - **Immutable comments** owned by tickets. Closed tickets refuse new comments.
 - **Domain events** for cross-module reactions: `TicketCreatedDomainEvent`, `TicketAssignedDomainEvent`, `TicketStatusChangedDomainEvent`, `TicketCommentAddedDomainEvent`.
-- **Soft delete + restore** on tickets and comments via `ISoftDeletable`.
+- **Soft delete + restore** on tickets and comments via `ISoftDeletable` — `Delete` trashes a ticket (its comments survive and return on restore), `ListTrashed` lists the trash, `Restore` brings it back.
 - **Search** by status, priority, assignee, and free text.
-- **9 fine-grained permissions** — View / Create / Update / Delete / Restore / Assign / Resolve / Reopen / Comment.
+- **10 fine-grained permissions** — View / Create / Update / Delete / Restore / Assign / Resolve / Reopen / Close / Comment.
 
 ## Architecture at a glance
 
@@ -44,9 +45,11 @@ src/Modules/Tickets/
 │   │   └── TicketsDbInitializer.cs              Seeds demo data
 │   ├── Features/v1/Tickets/
 │   │   ├── CreateTicket/
+│   │   ├── UpdateTicket/
 │   │   ├── AssignTicket/
 │   │   ├── ResolveTicket/
 │   │   ├── ReopenTicket/
+│   │   ├── CloseTicket/
 │   │   ├── AddTicketComment/
 │   │   ├── DeleteTicket/
 │   │   ├── RestoreTicket/
@@ -132,18 +135,21 @@ Every method that mutates state does three things consistently: validate the sou
 
 ## Public API
 
-Ten commands and queries in the Contracts assembly:
+Thirteen commands and queries in the Contracts assembly:
 
 | Type | Purpose |
 |---|---|
 | `CreateTicketCommand(title, description?, priority, assignedToUserId?)` | File a ticket; auto-numbered |
+| `UpdateTicketCommand(ticketId, title, description?, priority)` | Edit title, description, and priority (rejected on a Closed ticket) |
 | `AssignTicketCommand(ticketId, assigneeUserId?)` | Assign or unassign (null = unassign) |
 | `ResolveTicketCommand(ticketId, resolutionNote?)` | Mark resolved |
 | `ReopenTicketCommand(ticketId)` | Reopen a resolved/closed ticket |
+| `CloseTicketCommand(ticketId)` | Finalize a resolved ticket (Resolved → Closed) |
 | `AddTicketCommentCommand(ticketId, body)` | Post a comment |
+| `DeleteTicketCommand(ticketId)` | Soft-delete (trash) a ticket |
 | `RestoreTicketCommand(ticketId)` | Restore a soft-deleted ticket |
 | `GetTicketByIdQuery(ticketId)` | Fetch single ticket with comments |
-| `ListTicketCommentsQuery(ticketId, skip, take)` | Paginated comments |
+| `ListTicketCommentsQuery(ticketId, skip, take)` | Paginated comments (404 if the ticket doesn't exist) |
 | `SearchTicketsQuery(search?, statusFilter?, priorityFilter?, assignedToUserId?, skip, take)` | Advanced search |
 | `ListTrashedTicketsQuery(skip, take)` | View soft-deleted tickets |
 
@@ -153,18 +159,21 @@ Each command returns either `Unit` (mutations) or a typed response (`TicketRespo
 
 All under `/api/v1/tickets`, gated by the corresponding `Tickets.*` permission.
 
-| Verb | Route | Endpoint class |
-|---|---|---|
-| POST | `/` | `CreateTicketEndpoint` |
-| GET | `/{ticketId}` | `GetTicketByIdEndpoint` |
-| GET | `/search` | `SearchTicketsEndpoint` |
-| GET | `/trash` | `ListTrashedTicketsEndpoint` |
-| POST | `/{ticketId}/assign` | `AssignTicketEndpoint` |
-| POST | `/{ticketId}/resolve` | `ResolveTicketEndpoint` |
-| POST | `/{ticketId}/reopen` | `ReopenTicketEndpoint` |
-| POST | `/{ticketId}/restore` | `RestoreTicketEndpoint` |
-| GET | `/{ticketId}/comments` | `ListTicketCommentsEndpoint` |
-| POST | `/{ticketId}/comments` | `AddTicketCommentEndpoint` |
+| Verb | Route | Endpoint class | Permission |
+|---|---|---|---|
+| POST | `/` | `CreateTicketEndpoint` | `Tickets.Create` |
+| PUT | `/{ticketId}` | `UpdateTicketEndpoint` | `Tickets.Update` |
+| DELETE | `/{ticketId}` | `DeleteTicketEndpoint` | `Tickets.Delete` |
+| GET | `/{ticketId}` | `GetTicketByIdEndpoint` | `Tickets.View` |
+| GET | `/search` | `SearchTicketsEndpoint` | `Tickets.View` |
+| GET | `/trash` | `ListTrashedTicketsEndpoint` | `Tickets.View` |
+| POST | `/{ticketId}/assign` | `AssignTicketEndpoint` | `Tickets.Assign` |
+| POST | `/{ticketId}/resolve` | `ResolveTicketEndpoint` | `Tickets.Resolve` |
+| POST | `/{ticketId}/reopen` | `ReopenTicketEndpoint` | `Tickets.Reopen` |
+| POST | `/{ticketId}/close` | `CloseTicketEndpoint` | `Tickets.Close` |
+| POST | `/{ticketId}/restore` | `RestoreTicketEndpoint` | `Tickets.Restore` |
+| GET | `/{ticketId}/comments` | `ListTicketCommentsEndpoint` | `Tickets.View` |
+| POST | `/{ticketId}/comments` | `AddTicketCommentEndpoint` | `Tickets.Comment` |
 
 ## Domain events
 
@@ -186,29 +195,27 @@ These are in-module domain events. To react from another module (e.g. send an em
 
 ## How to extend
 
-### Add Close as a public command
+### Add a new state transition
 
-Today there's no `CloseTicketCommand` — the Closed state is reached via business logic (e.g. an auto-close timer or an admin sweep). Add it explicitly:
-
-```csharp
-// Modules.Tickets.Contracts/v1/Tickets/CloseTicket/CloseTicketCommand.cs
-public sealed record CloseTicketCommand(Guid TicketId, string? Reason) : ICommand<Unit>;
-```
-
-In `Ticket.cs`:
+`Close` (Resolved → Closed) ships as a first-class command, endpoint, and `Tickets.Close` permission — `Ticket.Close()` validates the source state, stamps `ClosedAtUtc`, and raises `TicketStatusChangedDomainEvent`. Use it as the template for any new transition you need (e.g. an `Escalate` step):
 
 ```csharp
-public void Close(string? reason)
+// 1. Domain — guard the source state, mutate, raise the event (Modules.Tickets/Domain/Ticket.cs)
+public void Escalate()
 {
-    if (Status != TicketStatus.Resolved)
-        throw new CustomException("Can only close a resolved ticket.", HttpStatusCode.Conflict);
-    Status = TicketStatus.Closed;
-    ClosedAtUtc = DateTime.UtcNow;
-    RaiseDomainEvent(new TicketStatusChangedDomainEvent(Id, TicketStatus.Closed));
+    if (Status is TicketStatus.Closed)
+        throw new CustomException("Cannot escalate a closed ticket.",
+            (IEnumerable<string>?)null, HttpStatusCode.Conflict);
+    Priority = TicketPriority.Critical;
+    UpdatedAtUtc = DateTime.UtcNow;
 }
+
+// 2. Contracts — EscalateTicketCommand(Guid TicketId) : ICommand<Guid>
+// 3. Feature folder — handler + {Command}Validator + endpoint with .RequirePermission(...)
+// 4. Register the endpoint in TicketsModule.MapEndpoints and add the permission constant
 ```
 
-Add the handler, validator, endpoint, and permission constant — follow the existing `Resolve` shape exactly.
+Follow the existing `CloseTicket` slice end-to-end — every command handler needs a `{Command}Validator` (enforced by `Architecture.Tests`).
 
 ### Email notifications on assignment
 
@@ -235,7 +242,7 @@ Resolved tickets carry `ResolvedAtUtc`. Add an `ExpectedResolutionAtUtc` field s
 
 ## Tests
 
-One integration test file at `src/Tests/Integration.Tests/Tests/Tickets/`. Coverage is light relative to feature completeness — if you customize the state machine, add unit tests on `Ticket` directly to cover every transition.
+Integration tests live at `src/Tests/Integration.Tests/Tests/Tickets/` and cover the lifecycle (create, search/filter, assign, resolve/reopen guards), the close/update/delete operations, the delete → restore round-trip (comments survive), and tenant isolation. If you customize the state machine, add unit tests on `Ticket` directly to cover every transition.
 
 ## Related
 

--- a/src/content/docs/modules/webhooks.mdx
+++ b/src/content/docs/modules/webhooks.mdx
@@ -1,7 +1,7 @@
 ---
 title: Webhooks module
-lastUpdated: 2026-05-19
-description: Tenant-scoped webhook subscriptions, open-generic event fan-out, HMAC-signed delivery, Hangfire dispatch with exponential backoff, and a delivery audit log.
+lastUpdated: 2026-06-01
+description: Tenant-scoped webhook subscriptions, open-generic event fan-out, HMAC-signed delivery with secrets encrypted at rest, permission-gated endpoints, Hangfire dispatch with exponential backoff, and a delivery audit log.
 sidebar:
   label: Webhooks
   order: 7
@@ -20,14 +20,16 @@ You publish integration events anyway (Chat does, Identity does, Files does). Th
 
 ## What ships in v10
 
-- **Tenant-scoped subscriptions** — each `WebhookSubscription` row belongs to a tenant and stores `Url`, `EventsCsv` (comma-separated list with `*` wildcard support), `SecretHash` (the HMAC key), `IsActive`.
+- **Tenant-scoped subscriptions** — each `WebhookSubscription` row belongs to a tenant and stores `Url`, `EventsCsv` (comma-separated list with `*` wildcard support), `SecretHash` (the HMAC signing secret, **encrypted at rest** — see below), `IsActive`.
+- **Signing secret encrypted at rest** — the secret is the HMAC key, so it must stay recoverable (a one-way hash would make signing impossible). It is encrypted with ASP.NET Data Protection (`IWebhookSecretProtector`) on create and decrypted only at sign time, so a database breach never exposes plaintext secrets.
+- **Permission-gated endpoints** — `Webhooks.View` / `Create` / `Delete` / `Test` (previously authentication-only).
 - **Open-generic event handler** — one `WebhookFanoutHandler<TEvent>` registered for every `IIntegrationEvent`; no per-event setup needed. When a new module publishes a new event, existing subscriptions automatically receive it.
 - **Tenant context restoration** — the fanout handler explicitly restores the tenant context before querying subscriptions, so Finbuckle's global query filter sees the right tenant. (This is the single most important gotcha — see below.)
 - **HMAC-SHA256 payload signing** — when `SecretHash` is set, every delivery includes `X-Webhook-Signature: sha256={hex}` so subscribers can verify authenticity.
 - **Hangfire delivery jobs** with `[AutomaticRetry]` — 5 attempts total, exponential backoff (30 s, 2 min, 10 min, 1 h).
 - **Transient vs permanent error classification** — 5xx, 408, 429 retried; other 4xx permanent.
 - **Delivery log** — every attempt (success or failure) appends a `WebhookDelivery` row with status code, duration, error.
-- **Five endpoints** for tenants to manage subscriptions and read the delivery log.
+- **Five permission-gated endpoints** for tenants to manage subscriptions and read the delivery log.
 - **HTTP resilience** via a named `HttpClient` "Webhooks" using `Microsoft.Extensions.Http.Resilience` (Polly v8).
 
 ## Architecture at a glance
@@ -118,8 +120,9 @@ public sealed class WebhookDispatchJob(IHttpClientFactory http, IWebhookDelivery
         };
         req.Headers.Add("X-Webhook-Event", eventType);
         req.Headers.Add("X-Webhook-Delivery-Id", Guid.NewGuid().ToString());
-        if (!string.IsNullOrEmpty(sub.SecretHash))
-            req.Headers.Add("X-Webhook-Signature", "sha256=" + signer.Sign(payload, sub.SecretHash));
+        var secret = secretProtector.Unprotect(sub.SecretHash);   // decrypt at sign time
+        if (!string.IsNullOrEmpty(secret))
+            req.Headers.Add("X-Webhook-Signature", "sha256=" + signer.Sign(payload, secret));
 
         var sw = Stopwatch.StartNew();
         try
@@ -146,21 +149,36 @@ public sealed class WebhookDispatchJob(IHttpClientFactory http, IWebhookDelivery
 
 | Type | Purpose |
 |---|---|
-| `CreateWebhookSubscriptionCommand(url, events[], secretHash?)` | Subscribe |
-| `DeleteWebhookSubscriptionCommand(subscriptionId)` | Soft-delete (IsActive = false) |
+| `CreateWebhookSubscriptionCommand(url, events[], secret?)` | Subscribe (the secret is encrypted before storage) |
+| `DeleteWebhookSubscriptionCommand(subscriptionId)` | Delete the subscription |
 | `TestWebhookSubscriptionCommand(subscriptionId, eventType?)` | Enqueue one-off test delivery |
 | `GetWebhookSubscriptionsQuery(paging)` | List active subscriptions for caller's tenant |
 | `GetWebhookDeliveriesQuery(subscriptionId?, paging)` | Delivery log |
 
+## Permissions
+
+Every endpoint is gated by a `Webhooks.*` permission (defined in `Modules.Webhooks.Contracts/Authorization/WebhooksPermissions.cs` and registered at module startup). `View` is a basic permission; the rest are assigned per role.
+
+| Permission | Grants |
+|---|---|
+| `Webhooks.View` | List subscriptions and read the delivery log |
+| `Webhooks.Create` | Create a subscription |
+| `Webhooks.Delete` | Delete a subscription |
+| `Webhooks.Test` | Send a one-off test delivery |
+
+<Callout type="warning" title="Grant the new permissions after upgrading">
+Before this release the endpoints were authentication-only — any signed-in user could manage every webhook in their tenant. They now require explicit `Webhooks.*` permissions, so add them to the roles that should manage webhooks or those users will get `403`.
+</Callout>
+
 ## Endpoints
 
-| Verb | Route | What it does |
-|---|---|---|
-| POST | `/api/v1/webhooks` | Create subscription |
-| DELETE | `/api/v1/webhooks/{id}` | Deactivate subscription |
-| GET | `/api/v1/webhooks` | List subscriptions |
-| GET | `/api/v1/webhooks/deliveries` | Delivery log (newest first) |
-| POST | `/api/v1/webhooks/test` | Test delivery |
+| Verb | Route | What it does | Permission |
+|---|---|---|---|
+| POST | `/api/v1/webhooks/subscriptions` | Create subscription | `Webhooks.Create` |
+| DELETE | `/api/v1/webhooks/subscriptions/{id}` | Delete subscription | `Webhooks.Delete` |
+| GET | `/api/v1/webhooks/subscriptions` | List subscriptions | `Webhooks.View` |
+| GET | `/api/v1/webhooks/subscriptions/{id}/deliveries` | Delivery log (newest first) | `Webhooks.View` |
+| POST | `/api/v1/webhooks/subscriptions/{id}/test` | Test delivery | `Webhooks.Test` |
 
 ## Headers on every delivery
 
@@ -206,7 +224,7 @@ The kit doesn't auto-purge the `WebhookDelivery` table. For high-volume tenants,
 
 ## Tests
 
-The module has no built-in tests — webhook delivery needs a controllable HTTP endpoint, which is integration-test infrastructure. Tests live in your CI/CD pipeline rather than in the repo.
+The module ships unit tests in `src/Tests/Webhooks.Tests/` (domain, validators, the fan-out handler, payload signer, and the secret protector — encryption round-trips and never stores plaintext) and end-to-end coverage in `src/Tests/Integration.Tests/Tests/Webhooks/` (subscription CRUD, signed delivery, dispatch outcomes/retry, pagination, and cross-tenant isolation) using a controllable in-process HTTP receiver.
 
 ## Related
 


### PR DESCRIPTION
Documents the backend changes shipped in code PR fullstackhero/dotnet-starter-kit#1273.

- **Tickets** — Close (Resolved→Closed), Update, Delete (soft-delete) are now first-class; refreshed the feature list, command + endpoint tables (added a permission column), the architecture tree, and replaced the obsolete "add Close yourself" section. Noted the comments-list 404.
- **Webhooks** — signing secret now encrypted at rest (Data Protection); endpoints are permission-gated (Webhooks.View/Create/Delete/Test) with an upgrade caution; corrected endpoint routes, delete semantics, and the stale "no tests" note.
- **Changelog** — 2026-06-01 post-10.0.0 entry + the documented outbox follow-up.

Verified with `npm run build` (Astro + Pagefind, 86 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)