### PR TITLE
docs(changelog): note Billing config key rename (GraceWindowDays -> GracePeriodDays)

### DIFF
--- a/src/content/docs/changelog/index.mdx
+++ b/src/content/docs/changelog/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-lastUpdated: 2026-06-20
+lastUpdated: 2026-06-24
 description: Release notes and version history for fullstackhero.
 sidebar:
   order: 1
@@ -10,6 +10,10 @@ seo:
 ---
 
 Notable changes to the kit, newest first.
+
+## 2026-06-24
+
+- **Config: the tenant billing grace-period setting was renamed `Billing:GraceWindowDays` → `Billing:GracePeriodDays` (breaking).** The option (bound in both `TenantBillingOptions` and Identity's `TenantGraceOptions`) is now named consistently with the "grace period" term used everywhere else in the kit; the default of 7 days is unchanged. Deployments that set `Billing:GraceWindowDays` (env `Billing__GraceWindowDays`) must rename the key to `Billing:GracePeriodDays`, otherwise the override is silently ignored and the default applies. No public contract change — the `GraceEndsUtc` tenant-status and integration-event fields are untouched. See PR [#1313](https://github.com/fullstackhero/dotnet-starter-kit/pull/1313).
 
 ## 2026-06-20
 


### PR DESCRIPTION
Companion docs change for [fullstackhero/dotnet-starter-kit#1313](https://github.com/fullstackhero/dotnet-starter-kit/pull/1313), which renames the tenant billing grace-period config key `Billing:GraceWindowDays` → `Billing:GracePeriodDays`.

Adds a `2026-06-24` changelog entry documenting the **breaking config change** so existing deployments rename the key (or the override is silently ignored). Default (7 days) and the public `GraceEndsUtc` fields are unchanged.

Merge alongside / after the code PR.
