### PR TITLE
fix(docs): repair anchor broken by em-dash-to-hyphen sweep

### DIFF
--- a/src/content/docs/frontend/architecture.mdx
+++ b/src/content/docs/frontend/architecture.mdx
@@ -218,7 +218,7 @@ Implementation details worth knowing:
 - Reconnects use SignalR's automatic-reconnect backoff plus an outer retry loop with jitter, capped at 60 s.
 - Transport is auto-negotiated (WebSockets → SSE → long-polling) for proxy-hostile networks.
 
-One connection per user session; every subscriber attaches via `on(event, handler)` and the returned function detaches it. The dashboard's chat page is the canonical user - see the [dashboard page](/docs/frontend/dashboard/#chat--the-realtime-showcase).
+One connection per user session; every subscriber attaches via `on(event, handler)` and the returned function detaches it. The dashboard's chat page is the canonical user - see the [dashboard page](/docs/frontend/dashboard/#chat---the-realtime-showcase).
 
 ## Error handling
 


### PR DESCRIPTION
## Root cause

Commit a96478cf (`style: replace all em dashes with hyphens across the site`) replaced every em dash (`—`) with a hyphen (`-`) site-wide. `github-slugger` (the same library Astro/Starlight use to generate heading anchors) **drops** em dashes entirely when slugging, but **keeps** hyphens as-is. That means the sweep silently changed the anchor for any heading that contained an em dash:

| heading | slug |
|---|---|
| `Chat — the realtime showcase` (before) | `chat--the-realtime-showcase` (2 hyphens) |
| `Chat - the realtime showcase` (after)  | `chat---the-realtime-showcase` (3 hyphens) |

Any internal link pointing at the old slug broke silently. `astro check` does not validate anchors inside link targets, so it passed with 0 errors both before and after the sweep, on both the broken and fixed link.

## Fix

`src/content/docs/frontend/architecture.mdx` linked to the "Chat - the realtime showcase" heading in `dashboard.mdx` using the pre-sweep slug. Updated the link to the current slug. The heading text itself is untouched, so the public heading and its URL fragment stay consistent with the rest of the post-sweep site (no new em dash introduced).

## Verification method

1. Extended a link-anchor checker (walks `src/content/docs`, computes slugs per file with the site's actual `github-slugger` dependency, and resolves every internal anchor link against them) to also cover same-file relative anchors (`](#anchor)`), not just cross-file ones (`](/docs/route#anchor)`). Total anchor-bearing links found across the site: 5. Before the fix, 1 was broken (the one described above); after, 0.
2. Before trusting the "new" slug, reproduced the **old** slug first by running the site's own `github-slugger` against the original em-dash heading text (`Chat — the realtime showcase`) and confirmed it produced byte-for-byte the same anchor (`chat--the-realtime-showcase`) that was in the broken link. Only after that check matched did I trust the slugger's output for the new heading text.
3. `npx astro check` -> 0 errors, 0 warnings (21 pre-existing hints, unrelated to this change).

## Scope

Single link fix, no heading text changed (would break the public URL and any external link), no prose rewritten. Not touching `npm run build`, which fails in `buildEnd` fetching a font from `fonts.gstatic.com` — same failure on unmodified `main`, unrelated to this change.